### PR TITLE
Added support for interim DSS load-by-reference mechanism

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ botocore==1.8.13
 chalice==1.1.0
 elasticsearch>=5.0.0,<6.0.0
 future==0.16.0
-hca==3.0.5
+hca==3.3.0


### PR DESCRIPTION
Currently, as an interim solution for Commons, (large) files located in external buckets are loaded into the DSS using a small stub containing the cloud URL(s) and the actual/correct metadata for the file (size, content-type, checksums). 
This requires a small change to the `dss-azul-indexer` to handle files loaded-by-reference, as described [here](https://docs.google.com/document/d/1QSa7Ubw-muyD_u0X_dq9WeKyK_dCJXi4Ex7S_pil1uk/edit#).
This is for the Commons pilot only and will be removed when support for foreign blobs is added to the `data-store`.

The primary reviewer for this change is @mjkrause.

Connects to BD2KGenomics/dss-azul-indexer#22